### PR TITLE
Set default message for nameless assertion

### DIFF
--- a/lib/Test2/Plugin/GitHub/Actions/AnnotateFailedTest.pm
+++ b/lib/Test2/Plugin/GitHub/Actions/AnnotateFailedTest.pm
@@ -48,7 +48,11 @@ sub _extract_summary_from_event {
     my $name_or_summary = $event->isa('Test2::Event::Fail') ? $event->name : $event->summary;
     # avoid uninitialized warning for regexp matching
     $name_or_summary //= '';
-    return $name_or_summary =~ /Nameless Assertion/ ? '' : $name_or_summary;
+    if ($name_or_summary =~ /Nameless Assertion/ || ! length $name_or_summary) {
+        return 'Test failed';
+    } else {
+        return $name_or_summary;
+    }
 }
 
 sub _extract_details_from_event {
@@ -63,11 +67,7 @@ sub _issue_error {
 
     my $stderr = test2_stderr();
 
-    if (length $detail) {
-        $stderr->printf("::error file=%s,line=%d::%s\n", $file, $line, _escape_data($detail));
-    } else {
-        $stderr->printf("::error file=%s,line=%d\n", $file, $line);
-    }
+    $stderr->printf("::error file=%s,line=%d::%s\n", $file, $line, _escape_data($detail));
 }
 
 # escape a message of workflow command.

--- a/t/annotate_no_name.t
+++ b/t/annotate_no_name.t
@@ -23,6 +23,6 @@ like $event, array {
     item event 'Ok';
 };
 
-is $call, [$file, $line, ''], 'annotate with error';
+is $call, [$file, $line, 'Test failed'], 'annotate with error';
 
 done_testing;


### PR DESCRIPTION
message is an essential parameter.
- https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message