### PR TITLE
Rewrite tests with Test2::Plugin::IOEvents

### DIFF
--- a/META.json
+++ b/META.json
@@ -53,7 +53,6 @@
       },
       "test" : {
          "requires" : {
-            "Module::Spy" : "0",
             "Test2::Plugin::IOEvents" : "0",
             "Test2::V0" : "0",
             "Test::More" : "0.98"

--- a/META.json
+++ b/META.json
@@ -54,6 +54,7 @@
       "test" : {
          "requires" : {
             "Module::Spy" : "0",
+            "Test2::Plugin::IOEvents" : "0",
             "Test2::V0" : "0",
             "Test::More" : "0.98"
          }

--- a/cpanfile
+++ b/cpanfile
@@ -10,5 +10,6 @@ on 'test' => sub {
     requires 'Module::Spy';
     requires 'Test::More', '0.98';
     requires 'Test2::V0';
+    requires 'Test2::Plugin::IOEvents';
 };
 

--- a/cpanfile
+++ b/cpanfile
@@ -7,7 +7,6 @@ requires 'Test2::API';
 requires 'URI::Escape';
 
 on 'test' => sub {
-    requires 'Module::Spy';
     requires 'Test::More', '0.98';
     requires 'Test2::V0';
     requires 'Test2::Plugin::IOEvents';

--- a/t/annotate.t
+++ b/t/annotate.t
@@ -1,14 +1,14 @@
 use strict;
 use warnings;
 use Test2::V0;
-use Module::Spy qw(spy_on);
+use Test2::Plugin::IOEvents;
+use Test2::API qw(test2_reset_io);
+test2_reset_io();
 
 my $file = __FILE__;
 my $line;
 
-my $g = spy_on('Test2::Plugin::GitHub::Actions::AnnotateFailedTest', '_issue_error');
-
-my $event = intercept {
+my $events = intercept {
     local $ENV{GITHUB_ACTIONS} = 'true';
     require Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
     Test2::Plugin::GitHub::Actions::AnnotateFailedTest->import;
@@ -16,13 +16,15 @@ my $event = intercept {
     $line = __LINE__ + 1;
     ok 0, 'failed';
 };
-my $call = $g->calls_most_recent;
-undef $g;
 
-like $event, array {
-    item event 'Ok';
+is $events, array {
+    event 'Ok';
+    event Output => sub {
+        field stream_name => 'STDERR';
+        call message => "::error file=$file,line=$line\::failed\n";
+    };
+    event 'Diag';
+    end;
 };
-
-is $call, [$file, $line, 'failed'], 'annotate with error';
 
 done_testing;

--- a/t/no_annotation_when_passed.t
+++ b/t/no_annotation_when_passed.t
@@ -1,11 +1,8 @@
 use strict;
 use warnings;
 use Test2::V0;
-use Module::Spy qw(spy_on);
 
-my $g = spy_on('Test2::Plugin::GitHub::Actions::AnnotateFailedTest', '_issue_error');
-
-intercept {
+my $events = intercept {
     local $ENV{GITHUB_ACTIONS} = 'true';
     require Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
     Test2::Plugin::GitHub::Actions::AnnotateFailedTest->import;
@@ -15,6 +12,11 @@ intercept {
     pass 'ok';
 };
 
-ok ! $g->called, 'no annotation';
+is $events, array {
+    event 'Ok';
+    event 'Ok';
+    event 'Ok';
+    end;
+};
 
 done_testing;

--- a/t/without_github_actions.t
+++ b/t/without_github_actions.t
@@ -1,11 +1,8 @@
 use strict;
 use warnings;
 use Test2::V0;
-use Module::Spy qw(spy_on);
 
-my $g = spy_on('Test2::Plugin::GitHub::Actions::AnnotateFailedTest', '_issue_error');
-
-intercept {
+my $events = intercept {
     local $ENV{GITHUB_ACTIONS} = undef;
     require Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
     Test2::Plugin::GitHub::Actions::AnnotateFailedTest->import;
@@ -13,6 +10,9 @@ intercept {
     ok 0, 'failed';
 };
 
-ok ! $g->called, 'disabled when not in GitHub Actions';
+is $events, array {
+    fail_events 'Ok';
+    end;
+};
 
 done_testing;


### PR DESCRIPTION
- Use [Test2::Plugin::IOEvents](https://metacpan.org/pod/Test2::Plugin::IOEvents) instead of [Module::Spy](https://metacpan.org/pod/Module::Spy)
- Rewrite tests to confirm that this plugin outputs workflow commands to STDERR