### PR TITLE
Show file context in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,6 @@ jobs:
         with:
           perl-version: ${{ matrix.perl-version }}
 
-      - run: cpanm -L local --installdeps .
+      - run: cpanm -L local --notest --installdeps .
 
       - run: prove -Ilocal/lib/perl5 -Ilib -lv t

--- a/lib/Test2/Plugin/GitHub/Actions/AnnotateFailedTest.pm
+++ b/lib/Test2/Plugin/GitHub/Actions/AnnotateFailedTest.pm
@@ -15,14 +15,15 @@ our $VERSION = "0.04";
 
 sub import {
     my ($class) = @_;
-
     return unless $ENV{GITHUB_ACTIONS};
-    state $loaded = 0; # avoid multiple callback addition
-    return if $loaded;
-    $loaded++;
+
+    state %loaded ; # avoid multiple callback additions per Test2::Hub
 
     test2_add_callback_post_load(sub {
         my $hub = test2_stack()->top;
+        return if $loaded{$hub->hid};
+        $loaded{$hub->hid}++;
+
         $hub->listen(\&listener, inherit => 1);
     });
 }

--- a/t/add_callback_only_once.t
+++ b/t/add_callback_only_once.t
@@ -3,6 +3,8 @@ use warnings;
 use Test2::V0;
 use Module::Spy qw(spy_on);
 
+use Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
+
 my $g = spy_on('Test2::Plugin::GitHub::Actions::AnnotateFailedTest', '_issue_error');
 
 intercept {

--- a/t/annotate.t
+++ b/t/annotate.t
@@ -3,6 +3,8 @@ use warnings;
 use Test2::V0;
 use Module::Spy qw(spy_on);
 
+use Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
+
 my $file = __FILE__;
 my $line;
 
@@ -17,6 +19,7 @@ my $event = intercept {
     ok 0, 'failed';
 };
 my $call = $g->calls_most_recent;
+pop @$call; # pop the last arg $file_context
 undef $g;
 
 like $event, array {

--- a/t/annotate_no_name.t
+++ b/t/annotate_no_name.t
@@ -3,6 +3,8 @@ use warnings;
 use Test2::V0;
 use Module::Spy qw(spy_on);
 
+use Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
+
 my $file = __FILE__;
 my $line;
 
@@ -17,6 +19,7 @@ my $event = intercept {
     ok 0;
 };
 my $call = $g->calls_most_recent;
+pop @$call; # pop the last arg $file_context
 undef $g;
 
 like $event, array {

--- a/t/annotate_with_details.t
+++ b/t/annotate_with_details.t
@@ -3,6 +3,8 @@ use warnings;
 use Test2::V0;
 use Module::Spy qw(spy_on);
 
+use Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
+
 my $file = __FILE__;
 my $line;
 
@@ -17,6 +19,7 @@ my $event = intercept {
     is 0, -1, 'not equal';
 };
 my $call = $g->calls_most_recent;
+pop @$call; # pop the last arg $file_context
 undef $g;
 
 my $fail = $event->[0];

--- a/t/multiline_escape.t
+++ b/t/multiline_escape.t
@@ -1,7 +1,8 @@
 use strict;
 use warnings;
-use Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
 use Test2::V0;
+
+use Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
 
 is +Test2::Plugin::GitHub::Actions::AnnotateFailedTest::_escape_data("hoge\r\nfuga"), 'hoge%0D%0Afuga';
 

--- a/t/no_annotation_when_passed.t
+++ b/t/no_annotation_when_passed.t
@@ -3,6 +3,8 @@ use warnings;
 use Test2::V0;
 use Module::Spy qw(spy_on);
 
+use Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
+
 my $g = spy_on('Test2::Plugin::GitHub::Actions::AnnotateFailedTest', '_issue_error');
 
 intercept {

--- a/t/use_diag_failure.t
+++ b/t/use_diag_failure.t
@@ -3,6 +3,8 @@ use warnings;
 use Test2::V0;
 use Module::Spy qw(spy_on);
 
+use Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
+
 my $file = __FILE__;
 my $line;
 
@@ -17,6 +19,7 @@ my $event = intercept {
     is 0, -1, 'not equal', '0 is not 1', 'oops!';
 };
 my $call = $g->calls_most_recent;
+pop @$call; # pop the last arg $file_context
 undef $g;
 
 my $fail = $event->[0];

--- a/t/without_github_actions.t
+++ b/t/without_github_actions.t
@@ -3,6 +3,8 @@ use warnings;
 use Test2::V0;
 use Module::Spy qw(spy_on);
 
+use Test2::Plugin::GitHub::Actions::AnnotateFailedTest;
+
 my $g = spy_on('Test2::Plugin::GitHub::Actions::AnnotateFailedTest', '_issue_error');
 
 intercept {


### PR DESCRIPTION
To make debugging easily, I'd like to add a file context around the test failure (±1 lines) like this:

<img width="636" alt="Screen Shot 2020-12-05 at 10 30 04" src="https://user-images.githubusercontent.com/101800/101229874-b52d7d00-36e5-11eb-8c3b-2dbc098fd101.png">

(screenshot from https://github.com/gfx/Test2-Plugin-GitHub-Actions-AnnotateFailedTest/actions/runs/401868252)

This also allows annotating this module itself to make debugging easily (841b155).